### PR TITLE
Upgrade xml dependency to v6

### DIFF
--- a/lib/flutter_svg_opt.dart
+++ b/lib/flutter_svg_opt.dart
@@ -56,7 +56,7 @@ Future<void> processSvg(File svg) async {
   final rawXml = await svg.readAsString();
   final doc = XmlDocument.parse(rawXml);
   final svgDoc = doc.firstElementChild;
-  late final XmlElement defsElement;
+  XmlElement? defsElement;
   final notDefsElements = <XmlElement>[];
 
   if (svgDoc == null) {
@@ -71,12 +71,14 @@ Future<void> processSvg(File svg) async {
     }
   }
 
+  if (defsElement == null) return;
+
   final builder = XmlBuilder();
   builder.element(
     'svg',
     attributes: getAttributeMap(svgDoc.attributes),
     nest: () {
-      builder.xml(defsElement.outerXml);
+      builder.xml(defsElement!.outerXml);
       for (final sibling in notDefsElements) {
         builder.xml(sibling.outerXml);
       }

--- a/lib/flutter_svg_opt.dart
+++ b/lib/flutter_svg_opt.dart
@@ -56,31 +56,26 @@ Future<void> processSvg(File svg) async {
   final rawXml = await svg.readAsString();
   final doc = XmlDocument.parse(rawXml);
   final svgDoc = doc.firstElementChild;
-  XmlElement? defsElement;
-  final notDefsElements = <XmlElement>[];
 
   if (svgDoc == null) {
     return;
   }
 
-  for (final element in svgDoc.childElements) {
-    if (element.name.qualified.toLowerCase() == 'defs') {
-      defsElement = element;
-    } else {
-      notDefsElements.add(element);
-    }
-  }
-
-  if (defsElement == null) return;
+  final reordered = svgDoc.childElements.toList();
+  bool isDefs(XmlElement e) => e.name.qualified.toLowerCase() == 'defs';
+  reordered.sort((a, b) {
+    if (isDefs(a)) return -1;
+    if (isDefs(b)) return 1;
+    return 0;
+  });
 
   final builder = XmlBuilder();
   builder.element(
     'svg',
     attributes: getAttributeMap(svgDoc.attributes),
     nest: () {
-      builder.xml(defsElement!.outerXml);
-      for (final sibling in notDefsElements) {
-        builder.xml(sibling.outerXml);
+      for (final element in reordered) {
+        builder.xml(element.outerXml);
       }
     },
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/Tokenyet/flutter_svg_opt
 dependencies:
   args: ^2.2.0
   path: ^1.8.0
-  xml: ^5.3.1
+  xml: ^6.0.1
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"


### PR DESCRIPTION
* Upgrade xml dependency to v6. This is required to be compatible with flutter_svg: ^1.1.6 which depends on xml: ^6
* Ignore SVG files that don't have a <defs> entry